### PR TITLE
Fix auth crash and add configurable CORS / env support

### DIFF
--- a/BACKEND/app.js
+++ b/BACKEND/app.js
@@ -15,6 +15,12 @@ import rateLimit from "express-rate-limit";
 dotenv.config();
 
 const app = express();
+app.set("trust proxy", 1);
+
+const allowedOrigins = (process.env.CORS_ORIGIN || "")
+  .split(",")
+  .map((origin) => origin.trim())
+  .filter(Boolean);
 
 app.use(helmet());
 
@@ -23,10 +29,18 @@ app.use(rateLimit({
   max: 100
 }));
 
-app.use(cors({
-  origin: "https://shorty-url-gray.vercel.app",
-  credentials: true
-}));
+app.use(
+  cors({
+    origin(origin, callback) {
+      if (!origin || allowedOrigins.length === 0 || allowedOrigins.includes(origin)) {
+        return callback(null, true);
+      }
+
+      return callback(new Error("Not allowed by CORS"));
+    },
+    credentials: true,
+  })
+);
 
 app.use(express.json());
 app.use(express.urlencoded({ extended: true }));

--- a/BACKEND/src/config/monogo.config.js
+++ b/BACKEND/src/config/monogo.config.js
@@ -1,9 +1,13 @@
 import mongoose from "mongoose";
-console.log(process.env.MONGO_URI);
+const mongoUri = process.env.MONGO_URI || process.env.MONGODB_URI;
 
 const connectDB = async () => {
   try {
-    const conn = await mongoose.connect(process.env.MONGO_URI, {
+    if (!mongoUri) {
+      throw new Error("MONGO_URI (or MONGODB_URI) is not defined");
+    }
+
+    const conn = await mongoose.connect(mongoUri, {
       useNewUrlParser: true,
       useUnifiedTopology: true,
     });

--- a/BACKEND/src/services/auth.service.js
+++ b/BACKEND/src/services/auth.service.js
@@ -6,8 +6,8 @@ export const registerUser = async (name, email, password) => {
     const user = await findUserByEmail(email)
     if(user) throw new ConflictError("User already exists")
     const newUser = await createUser(name, email, password)
-    const token = await signToken({id: newUser._id})
-    return {token,user}
+    const token = signToken({id: newUser._id})
+    return {token,user:newUser}
 }
 
 export const loginUser = async (email, password) => {
@@ -17,6 +17,5 @@ export const loginUser = async (email, password) => {
     const isPasswordValid = await user.comparePassword(password)
     if(!isPasswordValid) throw new Error("Invalid email or password")
     const token = signToken({id: user._id})
-    return {token,user:newUser}
+    return {token,user}
 }
-

--- a/README.md
+++ b/README.md
@@ -87,8 +87,18 @@ FRONTEND/
    ```Bash
    cd BACKEND
    npm install
-   # 💡 Don't forget to create your .env and add MONGODB_URI & PORT
+   # 💡 Don't forget to create your `.env` (see example below)
    npm start
+   ```
+
+   Example backend `.env` values:
+   ```env
+   PORT=5000
+   MONGO_URI=<your_mongodb_connection_string>
+   # MONGODB_URI is also supported as a fallback
+   JWT_SECRET=<your_jwt_secret>
+   APP_URL=http://localhost:5000/
+   CORS_ORIGIN=http://localhost:5173,https://your-frontend.vercel.app
    ```
 3️⃣ **Setup Frontend:**
 


### PR DESCRIPTION
### Motivation
- Fix a runtime crash in authentication caused by incorrect return values and an unnecessary `await`, which could break the server in production.
- Make CORS and proxy behavior configurable to support deployments behind reverse proxies (Render/Vercel) and multiple frontend origins.
- Improve MongoDB configuration compatibility by accepting either `MONGO_URI` or `MONGODB_URI` and failing early with a clear error when missing.
- Provide a concrete backend `.env` example in the README to make deployments and cross-origin setup explicit.

### Description
- Corrected `BACKEND/src/services/auth.service.js` to return `user:newUser` from `registerUser`, return `user` from `loginUser`, and removed an unnecessary `await` on `signToken`.
- Added `app.set("trust proxy", 1)` and replaced the hardcoded CORS origin with an env-driven allowlist parsed from `CORS_ORIGIN` in `BACKEND/app.js`.
- Updated Mongo connection in `BACKEND/src/config/monogo.config.js` to use `process.env.MONGO_URI || process.env.MONGODB_URI` and throw a clear error when neither is defined.
- Updated `README.md` to include an example backend `.env` showing `PORT`, `MONGO_URI`, `JWT_SECRET`, `APP_URL`, and `CORS_ORIGIN` usage.

### Testing
- Performed static checks with `node --check BACKEND/app.js`, `node --check BACKEND/src/services/auth.service.js`, and `node --check BACKEND/src/config/monogo.config.js`, all of which passed.
- Installed backend dependencies with `npm --prefix BACKEND install` and ran a production build of the frontend with `npm --prefix FRONTEND run build`, and the frontend build completed successfully.
- There are no automated unit tests in the project, so validation was limited to static checks and the successful frontend production build.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a00dfcd2d4832fb3bf0962845d46d8)